### PR TITLE
fix: disable default redis service

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -21,3 +21,10 @@
     state: started
     daemon_reload: yes
   with_items: "{{ redis_cluster_instances }}"
+
+- name: Ensure default redis service is down
+  systemd:
+    name: redis_6379
+    enabled: no
+    state: stopped
+    daemon_reload: yes

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -23,7 +23,7 @@ dbfilename dump_{{ item.port }}.rdb
 
 repl-diskless-sync {{ item.repl_diskless_sync | default('no') }}
 
-repl-diskless-delay {{ item.repl_diskless_delay | default('5') }}
+repl-diskless-sync-delay {{ item.repl_diskless_delay | default('5') }}
 
 repl-timeout {{ item.repl_timeout | default('60') }}
 


### PR DESCRIPTION
ansible should start only configured redis instances