### PR TITLE
feat: add new required packages

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -26,4 +26,3 @@
   - name: "Build redis {{ redis_cluster_version }} from the source"
     script: /tmp/redis_build.sh
   when: not is_installed.stat.exists
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,8 @@
     with_items:
       - tcl
       - wget
+      - make
+      - build-essential
 
   - name: Copy redis build script
     template:
@@ -24,3 +26,4 @@
   - name: "Build redis {{ redis_cluster_version }} from the source"
     script: /tmp/redis_build.sh
   when: not is_installed.stat.exists
+


### PR DESCRIPTION
- I had some problems to install redis and during the troubleshoot I was able to see there was missing make and build-essential package so the redis bash script would run and install the redis as needed. 

Had this problem when using a new Ubuntu AMI.