### PR TITLE
support for redis v5.0.7 and compatibility for Redhat OS family

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # redis version
-redis_cluster_version: 4.0.11
+redis_cluster_version: 5.0.7
 
 redis_cluster_masters:
   - name: redis-01.localhost

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,6 +14,14 @@
   with_items: "{{ redis_cluster_instances }}"
   notify: restart redis
 
+- name: Get pid of default redis on localhost 6379
+  shell: netstat -nltp | grep 127.0.0.1:6379 | awk '{print $7}' | cut -d '/' -f1
+  register: default_redis_pid_on_localhost6379
+
+- name: Kill default redis on localhost 6379
+  shell: kill -9 {{ default_redis_pid_on_localhost6379.stdout }}
+  when: default_redis_pid_on_localhost6379.stdout != ''
+
 - name: Ensure redis-server service is up
   systemd:
     name: "redis-server@{{ item.port }}"
@@ -22,9 +30,10 @@
     daemon_reload: yes
   with_items: "{{ redis_cluster_instances }}"
 
-- name: Ensure default redis service is down
-  systemd:
-    name: redis_6379
-    enabled: no
-    state: stopped
-    daemon_reload: yes
+# # This can not effectively shutdown 127.0.0.1:6379 redis (default redis service?)
+# - name: Ensure default redis service is down
+#   systemd:
+#     name: redis_6379
+#     enabled: no
+#     state: stopped
+#     daemon_reload: yes

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -16,18 +16,19 @@
     system: yes
     createhome: no
 
-- name: Install ruby
-  package:
-    name: ruby
-    state: present
+# redis-trib for redis version 3 / 4, not required for redis 5
+# - name: Install ruby
+#   package:
+#     name: ruby
+#     state: present
 
-- gem:
-    name: redis
-    version: 4.0.2
-    state: present
+# - gem:
+#     name: redis
+#     version: 4.0.2
+#     state: present
 
-- name: Install redis-trib from local file.
-  copy:
-    src: redis-trib.rb
-    dest: /usr/local/bin/redis-trib
-    mode: 0750
+# - name: Install redis-trib from local file.
+#   copy:
+#     src: redis-trib.rb
+#     dest: /usr/local/bin/redis-trib
+#     mode: 0750

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,14 +7,22 @@
 
 - block:
   - name: Install required packages to build
-    apt:
+    package:
       name: "{{ item }}"
       state: present
-    with_items:
+    loop:
       - tcl
-      - wget
       - make
       - build-essential
+    when:
+      - ansible_os_family == "Debian"
+
+  - name: Install required packages to build
+    package:
+      name: ['tcl', '@Development Tools']
+      state: present
+    when:
+      - ansible_os_family == "RedHat"
 
   - name: Copy redis build script
     template:

--- a/tasks/masters.yml
+++ b/tasks/masters.yml
@@ -1,16 +1,9 @@
 ---
-- name: DNS lookup of master nodes
-  debug:
-    msg: "{{ lookup('dig', item.name, 'qtype=A') }}"
-  register: dns_values
-  run_once: True
-  with_items: "{{ redis_cluster_masters }}"
-
 - name: Set redis_cluster_masters_ip
   set_fact:
-    redis_cluster_masters_ip: "{{ redis_cluster_masters_ip | default([]) + [item.msg] }}"
-  with_items: "{{ dns_values.results }}"
-  when: item.msg is defined
+    redis_cluster_masters_ip: "{{ redis_cluster_masters_ip | default([]) + [item.name] }}"
+  with_items: "{{ redis_cluster_masters }}"
+  # when: item.msg is defined
 
 - name: Set redis_cluster_masters_instances
   set_fact:
@@ -28,7 +21,7 @@
     msg: "{{ redis_cluster_masters_instances }}"
 
 - name: Create redis masters
-  shell: "printf 'yes' | redis-trib create {{ redis_cluster_masters_instances }}"
+  shell: "printf 'yes' | redis-cli --cluster create {{ redis_cluster_masters_instances }}"
   args:
     creates: /etc/redis/redis-cluster-masters.created
   run_once: True

--- a/tasks/slave.yml
+++ b/tasks/slave.yml
@@ -1,13 +1,7 @@
 ---
-- name: "DNS lookup of master node: {{ item_master.name }}"
-  debug:
-    msg: "{{ lookup('dig', item_master.name, 'qtype=A') }}"
-  run_once: True
-  register: dns_master_ip
-
 - name: Set master_ip and master_port
   set_fact:
-    master_ip: "{{ dns_master_ip.msg }}"
+    master_ip: "{{ item_master.name }}"
     master_port: "{{ item_master.port }}"
 
 - name: "Discover master id of {{ item_master.name }}"
@@ -25,25 +19,20 @@
   debug:
     var: master_id
 
-- name: "DNS lookup of slave node: {{ item_slave.name }}"
-  debug:
-    msg: "{{ lookup('dig', item_slave.name, 'qtype=A') }}"
-  register: dns_slave_ip
-
 - name: Set slave_ip and slave_port
   set_fact:
-    slave_ip: "{{ dns_slave_ip.msg }}"
+    slave_ip: "{{ item_slave.name }}"
     slave_port: "{{ item_slave.port }}"
 
 - name: Show add-node command
   debug:
-    msg: "redis-trib add-node --slave --master-id {{ master_id }} {{ slave_ip }}:{{ slave_port }} {{ master_ip }}:{{ master_port }}"
+    msg: "redis-cli add-node --cluster-slave {{ slave_ip }}:{{ slave_port }} {{ master_ip }}:{{ master_port }} --cluster-master-id {{ master_id }}"
   register: slave_command
 
 - debug: var=slave_command
 
 - name: Create redis slaves
-  shell: "printf 'yes' | redis-trib add-node --slave --master-id {{ master_id }} {{ slave_ip }}:{{ slave_port }} {{ master_ip }}:{{ master_port }}"
+  shell: "printf 'yes' | redis-cli add-node --cluster-slave {{ slave_ip }}:{{ slave_port }} {{ master_ip }}:{{ master_port }} --cluster-master-id {{ master_id }}"
   args:
     creates: /etc/redis/redis-cluster-slave-{{ slave_ip | replace('.','-') }}-{{ slave_port }}.created
   run_once: True

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,5 +1,7 @@
 # {{ ansible_managed }}
 
+bind 0.0.0.0
+
 daemonize no
 
 pidfile /var/run/redis/redis_{{ item.port }}.pid

--- a/templates/redis_build.sh.j2
+++ b/templates/redis_build.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget http://download.redis.io/releases/redis-{{redis_cluster_version}}.tar.gz
+curl -OL http://download.redis.io/releases/redis-{{redis_cluster_version}}.tar.gz
 tar xvzf redis-{{redis_cluster_version}}.tar.gz
 cd redis-{{redis_cluster_version}}
 make distclean


### PR DESCRIPTION
1. Update redis to v5.0.7
2. Compatible with Redhat OS family
3. Removed dependency wget
4. Removed dependency ruby